### PR TITLE
[4.0] Cassiopeia: Modify chromes to apply mod id with or without header, plus new chrome

### DIFF
--- a/templates/cassiopeia/html/layouts/chromes/cardGrey.php
+++ b/templates/cassiopeia/html/layouts/chromes/cardGrey.php
@@ -29,14 +29,14 @@ $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT
 
 $header = '<div class="card-header'. $headerClass .'"><h3>' . $module->title . '</h3/></div>';
 if ($module->content) : ?>
-<?php if ($module->showtitle) : ?>
-<div id="<?php echo $modId; ?>" class="<?php echo $moduleAttribs['class'] ?>">
-<?php echo $header; ?>
-<div class="card-body"><?php echo $module->content; ?></div>
-</div>
-<?php else : ?>
-<div id="<?php echo $modId; ?>" class="<?php echo $moduleAttribs['class'] ?>" aria-labelledby="<?php echo $module->title; ?>">
-<div class="card-body"><?php echo $module->content; ?></div>
-</div>
-<?php endif; ?>
+	<?php if ($module->showtitle) : ?>
+		<div id="<?php echo $modId; ?>" class="<?php echo $moduleAttribs['class'] ?>">
+			<?php echo $header; ?>
+			<div class="card-body"><?php echo $module->content; ?></div>
+		</div>
+	<?php else : ?>
+		<div id="<?php echo $modId; ?>" class="<?php echo $moduleAttribs['class'] ?>" aria-labelledby="<?php echo $module->title; ?>">
+			<div class="card-body"><?php echo $module->content; ?></div>
+		</div>
+	<?php endif; ?>
 <?php endif; ?>

--- a/templates/cassiopeia/html/layouts/chromes/cardGrey.php
+++ b/templates/cassiopeia/html/layouts/chromes/cardGrey.php
@@ -21,34 +21,22 @@ if ($module->content === null || $module->content === '')
 }
 
 $moduleTag              = $params->get('module_tag', 'div');
-$moduleAttribs          = [];
+$modulePos 		= $module->position;
 $moduleAttribs['class'] = $module->position . ' card card-grey ' . htmlspecialchars($params->get('moduleclass_sfx'), ENT_QUOTES, 'UTF-8');
+$modId 			= 'mod-' . $module->id;
 $headerTag              = htmlspecialchars($params->get('header_tag', 'h4'), ENT_QUOTES, 'UTF-8');
 $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
-$headerAttribs          = [];
-$headerAttribs['class'] = $headerClass;
 
-if ($module->showtitle) :
-	$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
-	$headerAttribs['id']             = 'mod-' . $module->id;
-
-	if ($headerClass !== 'card-title') :
-		$headerAttribs['class'] .= 'card-header ' . $headerClass;
-	endif;
-else:
-	$moduleAttribs['aria-label'] = $module->title;
-endif;
-
-$header = '<' . $headerTag . ' ' . ArrayHelper::toString($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
-?>
-<<?php echo $moduleTag; ?> <?php echo ArrayHelper::toString($moduleAttribs); ?>>
-	<?php if ($module->showtitle && $headerClass !== 'card-title') : ?>
-		<?php echo $header; ?>
-	<?php endif; ?>
-	<div class="card-body">
-		<?php if ($module->showtitle && $headerClass === 'card-title') : ?>
-			<?php echo $header; ?>
-		<?php endif; ?>
-		<?php echo $module->content; ?>
-	</div>
-</<?php echo $moduleTag; ?>>
+$header = '<div class="card-header'. $headerClass .'"><h3>' . $module->title . '</h3/></div>';
+if ($module->content) : ?>
+<?php if ($module->showtitle) : ?>
+<div id="<?php echo $modId; ?>" class="<?php echo $moduleAttribs['class'] ?>">
+<?php echo $header; ?>
+<div class="card-body"><?php echo $module->content; ?></div>
+</div>
+<?php else : ?>
+<div id="<?php echo $modId; ?>" class="<?php echo $moduleAttribs['class'] ?>" aria-labelledby="<?php echo $module->title; ?>">
+<div class="card-body"><?php echo $module->content; ?></div>
+</div>
+<?php endif; ?>
+<?php endif; ?>

--- a/templates/cassiopeia/html/layouts/chromes/default.php
+++ b/templates/cassiopeia/html/layouts/chromes/default.php
@@ -21,34 +21,23 @@ if ($module->content === null || $module->content === '')
 }
 
 $moduleTag              = $params->get('module_tag', 'div');
-$moduleAttribs          = [];
+$modulePos 		= $module->position;
 $moduleAttribs['class'] = $module->position . ' card ' . htmlspecialchars($params->get('moduleclass_sfx'), ENT_QUOTES, 'UTF-8');
-$headerTag              = htmlspecialchars($params->get('header_tag', 'h4'), ENT_QUOTES, 'UTF-8');
-$headerClass            = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
 $headerAttribs          = [];
-$headerAttribs['class'] = $headerClass;
+$modId = 'mod-' . $module->id;
+$headerTag = htmlspecialchars($params->get('header_tag', 'h4'), ENT_QUOTES, 'UTF-8');
+$headerClass = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
 
-if ($module->showtitle) :
-	$moduleAttribs['aria-labelledby'] = 'mod-' . $module->id;
-	$headerAttribs['id']             = 'mod-' . $module->id;
-
-	if ($headerClass !== 'card-title') :
-		$headerAttribs['class'] .= 'card-header ' . $headerClass;
-	endif;
-else:
-	$moduleAttribs['aria-label'] = $module->title;
-endif;
-
-$header = '<' . $headerTag . ' ' . ArrayHelper::toString($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
-?>
-<<?php echo $moduleTag; ?> <?php echo ArrayHelper::toString($moduleAttribs); ?>>
-	<?php if ($module->showtitle && $headerClass !== 'card-title') : ?>
-		<?php echo $header; ?>
-	<?php endif; ?>
-	<div class="card-body">
-		<?php if ($module->showtitle && $headerClass === 'card-title') : ?>
+$header = '<div class="card-header'. $headerClass .'"><h3>' . $module->title . '</h3/></div>';
+if ($module->content) : ?>
+	<?php if ($module->showtitle) : ?>
+		<div id="<?php echo $modId; ?>" class="<?php echo $moduleAttribs['class'] ?>">
 			<?php echo $header; ?>
-		<?php endif; ?>
-		<?php echo $module->content; ?>
-	</div>
-</<?php echo $moduleTag; ?>>
+			<div class="card-body"><?php echo $module->content; ?></div>
+		</div>
+	<?php else : ?>
+		<div id="<?php echo $modId; ?>" class="<?php echo $moduleAttribs['class'] ?>" aria-labelledby="<?php echo $module->title; ?>">
+			<div class="card-body"><?php echo $module->content; ?></div>
+		</div>
+	<?php endif; ?>
+<?php endif; ?>

--- a/templates/cassiopeia/html/layouts/chromes/noTitle.php
+++ b/templates/cassiopeia/html/layouts/chromes/noTitle.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Templates.crocosmia
+ *
+ * @copyright   Copyright (C) 2005 - 2019 Open Source Matters, Inc. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$module  = $displayData['module'];
+$params  = $displayData['params'];
+$attribs = $displayData['attribs'];
+
+$modulePos   = $module->position;
+$moduleTag   = $params->get('module_tag', 'div');
+$modId 		 = 'mod-' . $module->id;
+
+if ($module->content) : ?>
+	<div id="<?php echo $modId; ?>" class="<?php echo $modulePos; ?> <?php echo htmlspecialchars($params->get('moduleclass_sfx')); ?>"  aria-labelledby="<?php echo $module->title; ?>">
+		<div>
+		<?php echo $module->content; ?>
+		</div>
+	</<?php echo $moduleTag; ?>>
+<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #30678 .

### Summary of Changes
See code.

### Testing Instructions

1. Create a new new mod chrome with this code 
2. Assign that chrome to a style for a module position in the Cassiopeia template's index.php
3. Create a module and assign it to that module position
4. Check the html with the browser inspector with header set to both Show and Hide

There is also a NEW chrome, called noTitle.php which can be applied where it is not usual to have a title showing, e.g. the main menu or search module. This can be used as "style=noTitle" in place of "style=none" which will also allow for custom css styling if a module class is added. At the moment, module class is ignored if the style is 'none'.

### Actual result BEFORE applying this Pull Request
cardGrey.php and default.php chromes only applied the mod-id to the header (title) so if the header is not shown, then neither is the mod-id.

### Expected result AFTER applying this Pull Request
By using the two changed files and using the noTitle chrome instead of none, all modules will have their ids applied, which is useful for link anchors. Otherwise, no change to a visitor's view of the template.

### Documentation Changes Required
A note to say that module ids can be used as anchors.
